### PR TITLE
Incompatibility Issue with mhcgnomes version in SNAF Pipeline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ requires = [
     'dash==2.0.0',
     'dash-dangerously-set-inner-html==0.0.2',
     'mygene==3.2.2',
-    'adjustText==0.8'
+    'adjustText==0.8',
+    'mhcgnomes==1.7.0'
 ]
 
 setup(


### PR DESCRIPTION
Environment:
OS: Ubuntu 20.04
Python Version: 3.7.17
Virtual Environment: Python venv

Description:
I encountered an error while progressing through the tutorial for the SNAF pipeline. The issue occurred when executing the command `jcmq.run(hlas=hlas, outdir='./result')`.

Error Message:
The following exception was raised during the execution:

```
Exception: binding prediction error: cannot import name ‘Class2Pair’ from ‘mhcgnomes’ (/snaf-pipeline/.venv/lib/python3.7/site-packages/mhcgnomes/__init__.py)
```

Steps to Reproduce:
Set up a Python virtual environment in Ubuntu 20.04.
Follow the installation guide to install SNAF.
Proceed with the tutorial steps until reaching the `jcmq.run` command.

Observed Behavior:
Upon the installation of SNAF, mhcgnomes version 1.8.6 was automatically installed. However, this version led to the aforementioned exception.

Resolution Attempt:
Downgrading mhcgnomes to version 1.7.0 resolved the error, and the jcmq.run command executed successfully.

Suggestion:
It seems that the current version of mhcgnomes (1.8.6) is incompatible with the SNAF pipeline.   
A possible cause could be the absence of a fixed version requirement for mhcgnomes in [the mhcflurry requirements.txt](https://github.com/openvax/mhcflurry/blob/master/requirements.txt).   
It may be beneficial to specify a compatible version of mhcgnomes to ensure the stability of the SNAF pipeline.